### PR TITLE
Allow deactivate Approval Group

### DIFF
--- a/approval.py
+++ b/approval.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from trytond.model import Workflow, ModelSQL, ModelView, fields
+from trytond.model import Workflow, ModelSQL, ModelView, fields, DeactivableMixin
 from trytond.pyson import Eval, Bool
 from trytond.pool import Pool
 from trytond.transaction import Transaction
@@ -9,7 +9,7 @@ from trytond.exceptions import UserError
 __all__ = ['Group', 'GroupUser', 'Request']
 
 
-class Group(ModelSQL, ModelView):
+class Group(ModelSQL, ModelView, DeactivableMixin):
     'Approval Group'
     __name__ = 'approval.group'
     name = fields.Char('Name', required=True)

--- a/view/group_form.xml
+++ b/view/group_form.xml
@@ -6,6 +6,8 @@
     <field name="name"/>
     <label name="model"/>
     <field name="model"/>
+    <label name="active"/>
+    <field name="active" xexpand="0" width="25"/>
     <separator name="users" colspan="4"/>
     <field name="users" colspan="4"/>
 </form>

--- a/view/group_form.xml
+++ b/view/group_form.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <!-- The COPYRIGHT file at the top level of this repository contains the full
      copyright notices and license terms. -->
-<form>
+<form col="6">
     <label name="name"/>
-    <field name="name"/>
+    <field name="name" xexpand="1"/>
     <label name="model"/>
     <field name="model"/>
     <label name="active"/>
-    <field name="active" xexpand="0" width="25"/>
-    <separator name="users" colspan="4"/>
-    <field name="users" colspan="4"/>
+    <field name="active" xexpand="0" width="100"/>
+    <separator name="users" colspan="6"/>
+    <field name="users" colspan="6"/>
 </form>


### PR DESCRIPTION
Could be nice to implement the option of deactivating approval groups cause when selecting an approval group it's unnecessary to still showing the ones that are obsolete, but at the same time you want to keep the history. A case that has happened to us is that we have created an approval group for a specific area of our company and over time that area has been divided in two different areas. As a result, we have created two new approval groups for each one and the other now is no longer used. 
Does this improvement make sense for you in your module? If not, we can make it custom.