### PR TITLE
Fix Request.group domain

### DIFF
--- a/approval.py
+++ b/approval.py
@@ -64,7 +64,7 @@ class Request(Workflow, ModelSQL, ModelView):
     group = fields.Many2One('approval.group', 'Group',
         domain=[
             ['OR',
-                ('name', '=', None),
+                ('model', '=', None),
                 ('model', '=', Eval('model'))],
             ])
     model = fields.Function(fields.Many2One('ir.model', 'Model'),


### PR DESCRIPTION
Commit 50ef2c7 wrongly updated that domain.
Here, 'model' refers to the model of the approval group.